### PR TITLE
Cardinal Bumper -> Square Hitbox

### DIFF
--- a/Code/Finished With Sprites/DeadlyWater.cs
+++ b/Code/Finished With Sprites/DeadlyWater.cs
@@ -78,8 +78,6 @@ namespace Celeste.Mod.JackalHelper.Entities
 
 			height = data.Height;
 			width = data.Width;
-			Console.WriteLine(Position);
-			Console.WriteLine(killbox.Position);
 			hitbox = new Hitbox(data.Width, currentHeight);
 			rect = new Rectangle((int)Position.X, (int)Position.Y, data.Width, data.Height);
 


### PR DESCRIPTION
- Replaced single hitbox with one hitbox per side
- Hitboxes are a bit smaller/shortened per side to minimize hitting multiple hitboxes
- Tested all of Hydroshock, feels a lot better, lmk if you have any questions

There is probably a more "optimal" way to do things (e.g. one hitbox where you compare amount of overlap/direction between player hitbox and bumper hitbox), but this was a relatively quick fix that works a lot better.